### PR TITLE
Connected extension to cookie consent feature of upcoming PWA version

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0
+### Added
+- Support for PWA cookie consent feature. Wizards are not shown when "comfort" cookie consent is not given. Instead a fallback message is shown that describes how to activate the feature.
+
 ## 1.0.0
 
 - Initial Release: "Chatchamp Wizard"

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta.6",
+  "version": "1.1.0",
   "id": "@shopgate-project/chatchamp-wizard",
   "components": [
     {

--- a/frontend/components/Wizard/CookieConsentFallback.jsx
+++ b/frontend/components/Wizard/CookieConsentFallback.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { css } from 'glamor';
+import { Link, I18n } from '@shopgate/engage/components';
+import { themeConfig } from '@shopgate/engage';
+
+const { colors } = themeConfig;
+
+let PRIVACY_SETTINGS_PATTERN;
+
+try {
+  // Try to import cookie consent related modules. "require()" is used since the currently deployed
+  // PWA might not have the required modules implemented yet.
+
+  /* eslint-disable eslint-comments/no-unlimited-disable */
+  /* eslint-disable */
+  ({ PRIVACY_SETTINGS_PATTERN } = require('@shopgate/engage/tracking/constants'));
+  /* eslint-enable  */
+} catch (e) {
+  // nothing to do here
+}
+
+const classes = {
+  root: css({
+    padding: '16px 32px',
+    display: 'flex',
+    alignItems: 'center',
+    flexDirection: 'column',
+    textAlign: 'center',
+    gap: 16,
+    margin: 'auto',
+  }),
+  link: css({
+    width: 'initial',
+    color: colors.accent,
+    fontWeight: 500,
+  }).toString(),
+};
+
+/**
+ * The CookieConsentFallback component is rendered when the Chatchamp wizard can't be shown
+ * due to missing comfort cookies consent.
+ * @returns {JSX.Element}
+ */
+const CookieConsentFallback = () => (
+  <div className={classes.root}>
+    <I18n.Text string="shopgateProject-chatchampWizard.cookieConsentMessage" />
+
+    {PRIVACY_SETTINGS_PATTERN && (
+    <Link href={PRIVACY_SETTINGS_PATTERN} className={classes.link}>
+      <I18n.Text string="shopgateProject-chatchampWizard.openPrivacySettings" />
+    </Link>
+    )}
+  </div>
+);
+
+export default CookieConsentFallback;

--- a/frontend/components/Wizard/index.jsx
+++ b/frontend/components/Wizard/index.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { css } from 'glamor';
 import classNames from 'classnames';
 import { useTheme, useRoute, logger } from '@shopgate/engage/core';
-import { getProductFetching } from '../../selectors';
+import { getProductFetching, getIsBlockedByCookieConsent } from '../../selectors';
 import { customerId, iFrameURL, pageTitleMapping } from '../../config';
 
 const styles = {
@@ -27,6 +27,7 @@ const styles = {
  */
 const makeMapStateToProps = () => state => ({
   productFetching: getProductFetching(state),
+  isBlockedByCookieConsent: getIsBlockedByCookieConsent(state),
 });
 
 /**
@@ -52,6 +53,7 @@ const ChatchampWizard = ({
   productFetching,
   showTabBar,
   hideTabBar,
+  isBlockedByCookieConsent,
 }) => {
   const { View, AppBar } = useTheme();
   const { params: { wizardId } } = useRoute();
@@ -120,21 +122,25 @@ const ChatchampWizard = ({
   return (
     <View noKeyboardListener>
       <AppBar title={pageTitle} />
-      <div className={classNames(styles.iframeWrapper, 'chatchamp-iframe-wrapper')}>
-        <iframe
-          ref={iframeRef}
-          src={iFrameSrc}
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-          className={classNames(styles.iframe, 'chatchamp-iframe')}
-          title="chatchamp-iframe"
-        />
-      </div>
+      { /* TODO add fallback text */}
+      { !isBlockedByCookieConsent && (
+        <div className={classNames(styles.iframeWrapper, 'chatchamp-iframe-wrapper')}>
+          <iframe
+            ref={iframeRef}
+            src={iFrameSrc}
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+            className={classNames(styles.iframe, 'chatchamp-iframe')}
+            title="chatchamp-iframe"
+          />
+        </div>
+      )}
     </View>
   );
 };
 
 ChatchampWizard.propTypes = {
   hideTabBar: PropTypes.func.isRequired,
+  isBlockedByCookieConsent: PropTypes.bool.isRequired,
   productFetching: PropTypes.bool.isRequired,
   showTabBar: PropTypes.func.isRequired,
 };

--- a/frontend/components/Wizard/index.jsx
+++ b/frontend/components/Wizard/index.jsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import { useTheme, useRoute, logger } from '@shopgate/engage/core';
 import { getProductFetching, getIsBlockedByCookieConsent } from '../../selectors';
 import { customerId, iFrameURL, pageTitleMapping } from '../../config';
+import CookieConsentFallback from './CookieConsentFallback';
 
 const styles = {
   iframe: css({
@@ -122,8 +123,7 @@ const ChatchampWizard = ({
   return (
     <View noKeyboardListener>
       <AppBar title={pageTitle} />
-      { /* TODO add fallback text */}
-      { !isBlockedByCookieConsent && (
+      { !isBlockedByCookieConsent ? (
         <div className={classNames(styles.iframeWrapper, 'chatchamp-iframe-wrapper')}>
           <iframe
             ref={iframeRef}
@@ -133,6 +133,8 @@ const ChatchampWizard = ({
             title="chatchamp-iframe"
           />
         </div>
+      ) : (
+        <CookieConsentFallback />
       )}
     </View>
   );

--- a/frontend/locale/de-DE.json
+++ b/frontend/locale/de-DE.json
@@ -1,5 +1,7 @@
 {
   "shopgateProject-chatchampWizard": {
-    "productNotFoundMessage": "Produkt nicht gefunden"
+    "productNotFoundMessage": "Produkt nicht gefunden",
+    "cookieConsentMessage": "Um unseren Produkt-Finder nutzen zu können, müssen die Komfort-Cookies aktiviert sein. Bitte aktivieren Sie diese in den Datenschutz-Einstellungen und kehren Sie dann auf diese Seite zurück um den Produkt-Finder zu verwenden.",
+    "openPrivacySettings": "Datenschutzeinstellungen öffnen"
   }
 }

--- a/frontend/locale/en-US.json
+++ b/frontend/locale/en-US.json
@@ -1,5 +1,7 @@
 {
   "shopgateProject-chatchampWizard": {
-    "productNotFoundMessage": "Product not found"
+    "productNotFoundMessage": "Product not found",
+    "cookieConsentMessage": "To use our product finder, comfort cookies must be enabled. You can enable them in the data privacy settings and then come back to this page to use the product finder.",
+    "openPrivacySettings": "Open Privacy Settings"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/chatchamp-wizard",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "scripts": {
     "lint": "eslint --parser babel-eslint --ignore-path ../.gitignore --ignore-path .eslintignore --ext .js --ext .jsx .",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/frontend/selectors/index.js
+++ b/frontend/selectors/index.js
@@ -1,5 +1,20 @@
 import { createSelector } from 'reselect';
 
+let getAreComfortCookiesAccepted;
+
+try {
+  // Try to import cookie consent related modules. "require()" is used since the currently deployed
+  // PWA might not have the required modules implemented yet.
+
+  /* eslint-disable eslint-comments/no-unlimited-disable */
+  /* eslint-disable */
+  ({ getAreComfortCookiesAccepted } = require('@shopgate/engage/tracking/selectors'));
+  /* eslint-enable  */
+} catch (e) {
+  // Configure fallbacks in case of an import error
+  getAreComfortCookiesAccepted = () => true;
+}
+
 const statePrefix = '@shopgate-project/chatchamp-wizard/reducer';
 
 /**
@@ -11,9 +26,18 @@ const getExtensionsState = state => state.extensions[statePrefix];
 
 /**
  * Selector to determine if the extension subscription is currently fetching
- * @returns {Function}
+ * @returns {boolean}
  */
 export const getProductFetching = createSelector(
   getExtensionsState,
   extensionState => extensionState.fetching
+);
+
+/**
+ * Selector to determine if the Wizard is blocked by a rejected comfort cookie consent.
+ * @returns {boolean}
+ */
+export const getIsBlockedByCookieConsent = createSelector(
+  getAreComfortCookiesAccepted,
+  isAllowed => !isAllowed
 );


### PR DESCRIPTION
This pull request adds support for the cookie consent feature of the upcoming PWA version. The Chatchamp wizard will only be shown when "comfort" cookies are accepted. If not, a text message is shown that describes how to activate the feature.

When deployed with an old PWA version that doesn't support the cookie consent yet, the extension will work as before.

Since the cookie consent feature is not released yet, please use the CURB-2434-cookie-settings of the PWA repository for testing.